### PR TITLE
remove usage of const fn

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-#![feature(const_fn)]
 #![feature(type_ascription)]
 
 #[macro_use]
@@ -35,6 +34,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{Instant, SystemTime};
+use std::u64;
 
 #[derive(Debug)]
 pub struct AnalysisHost<L: AnalysisLoader = CargoAnalysisLoader> {
@@ -76,7 +76,7 @@ pub type Span = span::Span<span::ZeroIndexed>;
 pub struct Id(u64);
 
 // Used to indicate a missing index in the Id.
-pub const NULL: Id = Id(u64::max_value());
+pub const NULL: Id = Id(u64::MAX);
 
 type Blacklist<'a> = &'a [&'static str];
 

--- a/src/lowering.rs
+++ b/src/lowering.rs
@@ -21,6 +21,7 @@ use std::collections::HashMap;
 use std::iter::Extend;
 use std::path::{Path, PathBuf};
 use std::time::Instant;
+use std::u32;
 
 // f is a function used to record the lowered crate into analysis.
 pub fn lower<F, L>(
@@ -336,7 +337,7 @@ impl CrateReader {
     // }
 
     fn id_from_compiler_id(&self, id: &data::Id) -> Id {
-        if id.krate == u32::max_value() || id.index == u32::max_value() {
+        if id.krate == u32::MAX || id.index == u32::MAX {
             return NULL;
         }
         // We build an id by looking up the local crate number into a global crate number and using


### PR DESCRIPTION
This is needed to bootstrap with rust-lang/rust#43017. We could instead change the feature gate from `#![feature(const_fn)]` to `#![feature(const_max_value)]` but these module consts are already stable.