### PR TITLE
Add defs_for_name, needed to support workspace/symbol in rls

### DIFF
--- a/src/analysis.rs
+++ b/src/analysis.rs
@@ -211,6 +211,16 @@ impl Analysis {
         self.for_each_crate(|c| c.defs_per_file.get(file).map(&f))
     }
 
+    pub fn defs_for_name(&self, name: &str) -> Vec<Def> {
+        self.for_all_crates(|c| {
+            c.def_names.get(name).map(|ids| {
+                ids.into_iter()
+                    .flat_map(|id| c.defs.get(id).map(|def| def.clone()))
+                    .collect()
+            })
+        })
+    }
+
     pub fn with_def_names<F, T>(&self, name: &str, f: F) -> Vec<T>
     where
         F: Fn(&Vec<Id>) -> Vec<T>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -346,6 +346,23 @@ impl<L: AnalysisLoader> AnalysisHost<L> {
         })
     }
 
+    pub fn name_defs(&self, name: &str) -> AResult<Vec<Def>> {
+        let t_start = Instant::now();
+        let result = self.with_analysis(|a| {
+            let defs = a.defs_for_name(name);
+            info!("defs_for_name {:?}", &defs);
+            Some(defs)
+        });
+
+        let time = t_start.elapsed();
+        info!(
+            "name_defs: {}",
+            time.as_secs() as f64 + time.subsec_nanos() as f64 / 1_000_000_000.0
+        );
+
+        result
+    }
+
     /// Search for a symbol name, returns a list of spans matching defs and refs
     /// for that name.
     pub fn search(&self, name: &str) -> AResult<Vec<Span>> {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -191,6 +191,12 @@ fn test_hello() {
     assert_eq!(refs[0].range.row_start.0, 0);
     assert_eq!(refs[1].file, Path::new("test_data/hello/src/main.rs"));
     assert_eq!(refs[1].range.row_start.0, 6);
+    let defs = host.name_defs("print_hello").unwrap();
+    assert_eq!(defs.len(), 1);
+    let hello_def = &defs[0];
+    assert_eq!(hello_def.name, "print_hello");
+    assert_eq!(hello_def.kind, DefKind::Function);
+    assert_eq!(hello_def.span.range.row_start.0 , 0);
 
     let ids = host.search_for_id("main").unwrap();
     assert_eq!(ids.len(), 1);
@@ -206,6 +212,12 @@ fn test_hello() {
     assert_eq!(refs.len(), 1);
     assert_eq!(refs[0].file, Path::new("test_data/hello/src/main.rs"));
     assert_eq!(refs[0].range.row_start.0, 5);
+    let defs = host.name_defs("main").unwrap();
+    assert_eq!(defs.len(), 1);
+    let main_def = &defs[0];
+    assert_eq!(main_def.name, "main");
+    assert_eq!(main_def.kind, DefKind::Function);
+    assert_eq!(main_def.span.range.row_start.0 , 5);
 
     let ids = host.search_for_id("name").unwrap();
     assert_eq!(ids.len(), 1);
@@ -225,6 +237,12 @@ fn test_hello() {
     assert_eq!(refs[0].range.row_start.0, 1);
     assert_eq!(refs[1].file, Path::new("test_data/hello/src/main.rs"));
     assert_eq!(refs[1].range.row_start.0, 2);
+    let defs = host.name_defs("name").unwrap();
+    assert_eq!(defs.len(), 1);
+    let name_def = &defs[0];
+    assert_eq!(name_def.name, "name");
+    assert_eq!(name_def.kind, DefKind::Local);
+    assert_eq!(name_def.span.range.row_start.0 , 1);
 }
 
 // TODO


### PR DESCRIPTION
Building towards https://github.com/rust-lang-nursery/rls/issues/353

Thoughts?

Wondering if we can play with the functions in `analysis.rs` and reuse a bit more logic, but probably best done in another PR.