### PR TITLE
Stub out a simple benchmark

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,7 @@ name = "rls-analysis"
 version = "0.7.0"
 dependencies = [
  "derive-new 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-data 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rls-span 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -17,6 +18,11 @@ dependencies = [
  "quote 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.8.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "lazy_static"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "log"
@@ -66,6 +72,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
 "checksum derive-new 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "41be6ca3b99e0c0483fb2389685448f650459c3ecbe4e18d7705d8010ec4ab8e"
+"checksum lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c9e5e58fa1a4c3b915a561a78a22ee0cac6ab97dca2504428bc1cb074375f8d5"
 "checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum quote 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5cf478fe1006dbcc72567121d23dbdae5f1632386068c5c86ff4f645628504"
 "checksum rls-data 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6aea328fa69702c1b0fc395f2c71eae954bf984ac1e418c72f69221b6e3d15ff"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,6 @@ log = "0.3"
 rls-data = "= 0.11"
 rls-span = "0.4"
 derive-new = "0.3"
+
+[dev-dependencies]
+lazy_static = "0.2"

--- a/benches/std_api_crate.rs
+++ b/benches/std_api_crate.rs
@@ -1,0 +1,90 @@
+#![feature(test)]
+
+extern crate rls_analysis;
+#[macro_use]
+extern crate derive_new;
+#[macro_use]
+extern crate lazy_static;
+extern crate test;
+use test::Bencher;
+
+use std::path::{Path, PathBuf};
+use std::sync::RwLock;
+
+use rls_analysis::{AnalysisHost, AnalysisLoader};
+
+#[derive(Clone, new)]
+struct TestAnalysisLoader {
+    path: PathBuf,
+}
+
+impl AnalysisLoader for TestAnalysisLoader {
+    fn needs_hard_reload(&self, _path_prefix: &Path) -> bool {
+        true
+    }
+
+    fn fresh_host(&self) -> AnalysisHost<Self> {
+        AnalysisHost::new_with_loader(self.clone())
+    }
+
+    fn set_path_prefix(&self, _path_prefix: &Path) {}
+
+    fn abs_path_prefix(&self) -> Option<PathBuf> {
+        panic!();
+    }
+
+    fn iter_paths<F, T>(&self, f: F) -> Vec<T>
+    where
+        F: Fn(&Path) -> Vec<T>,
+    {
+        let paths = &[&self.path];
+        paths.iter().flat_map(|p| f(p).into_iter()).collect()
+    }
+}
+
+lazy_static! {
+    static ref STDLIB_FILE_PATH: PathBuf = PathBuf::from("/checkout/src/libstd/lib.rs");
+    static ref STDLIB_DATA_PATH: PathBuf = PathBuf::from("test_data/rust-analysis");
+
+    static ref HOST: RwLock<AnalysisHost<TestAnalysisLoader>> = {
+        let host = AnalysisHost::new_with_loader(TestAnalysisLoader::new(
+            STDLIB_DATA_PATH.clone(),
+        ));
+        host.reload(&STDLIB_DATA_PATH, &STDLIB_DATA_PATH).unwrap();
+        RwLock::new(host)
+    };
+}
+
+#[bench]
+fn search_for_id(b: &mut Bencher) {
+    let host = HOST.read().unwrap();
+
+    b.iter(|| {
+        let _ = host.search_for_id("no_std");
+    });
+}
+
+#[bench]
+fn search(b: &mut Bencher) {
+    let host = HOST.read().unwrap();
+    b.iter(|| {
+        let _ = host.search("some_inexistent_symbol");
+        
+    })
+}
+
+#[bench]
+fn symbols(b: &mut Bencher) {
+    let host = HOST.read().unwrap();
+    b.iter(|| {
+        let _ = host.symbols(&STDLIB_FILE_PATH);
+    })
+}
+
+#[bench]
+fn reload(b: &mut Bencher) {
+    let host = HOST.write().unwrap();
+    b.iter(|| {
+        host.reload(&STDLIB_DATA_PATH, &STDLIB_DATA_PATH).unwrap();
+    })
+}


### PR DESCRIPTION
WIP, just want to see if it's a good approach and if I should create more (different) benchmarks in this spirit.

Currently this uses Cargo benchmarks and created a couple of them for the stdlib distro crate, here's an example output:
```
     Running target/release/deps/std_api_crate-3b898250cb490e2d

running 4 tests
test reload        ... bench:      17,294 ns/iter (+/- 2,891)
test search        ... bench:          89 ns/iter (+/- 7)
test search_for_id ... bench:          28 ns/iter (+/- 2)
test symbols       ... bench:          30 ns/iter (+/- 3)

test result: ok. 0 passed; 0 failed; 0 ignored; 4 measured; 0 filtered out
```

@nrc do you think this is a good approach (at least until we expand our test/benchmark suite)?