### PR TITLE
Support multiple crate types and versions (and multiple passed directly in-memory)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,7 +24,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "rls-analysis"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "derive-new 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rls-analysis"
-version = "0.7.2"
+version = "0.8.0"
 authors = ["Nick Cameron <ncameron@mozilla.com>"]
 description = "Library for processing rustc's save-analysis data for the RLS"
 license = "Apache-2.0/MIT"

--- a/benches/std_api_crate.rs
+++ b/benches/std_api_crate.rs
@@ -1,3 +1,11 @@
+// Copyright 2017 The RLS Project Developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
 #![feature(test)]
 
 extern crate rls_analysis;
@@ -27,19 +35,13 @@ impl AnalysisLoader for TestAnalysisLoader {
         AnalysisHost::new_with_loader(self.clone())
     }
 
-    fn set_path_prefix(&self, _path_prefix: &Path) {}
+    fn set_path_prefix(&mut self, _path_prefix: &Path) {}
 
     fn abs_path_prefix(&self) -> Option<PathBuf> {
         panic!();
     }
 
-    fn iter_paths<F, T>(&self, f: F) -> Vec<T>
-    where
-        F: Fn(&Path) -> Vec<T>,
-    {
-        let paths = &[&self.path];
-        paths.iter().flat_map(|p| f(p).into_iter()).collect()
-    }
+    fn search_directories(&self) -> Vec<PathBuf> { vec![self.path.clone()] }
 }
 
 lazy_static! {

--- a/src/listings/mod.rs
+++ b/src/listings/mod.rs
@@ -59,7 +59,7 @@ impl DirectoryListing {
             path: path.components()
                 .map(|c| c.as_os_str().to_str().unwrap().to_owned())
                 .collect(),
-            files: files,
+            files,
         })
     }
 }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -6,61 +6,67 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
+//! Defines an `AnalysisLoader` trait, which allows to specify directories
+//! from which save-analysis JSON files can be read. Also supplies a
+//! default implementation `CargoAnalysisLoader` for Cargo-emitted save-analysis
+//! files.
+
 use std::ffi::OsStr;
+use std::fmt;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::sync::Mutex;
 
-use raw::Target;
 use AnalysisHost;
 
 #[derive(Debug)]
 pub struct CargoAnalysisLoader {
-    pub path_prefix: Mutex<Option<PathBuf>>,
+    pub path_prefix: Option<PathBuf>,
     pub target: Target,
 }
 
+impl CargoAnalysisLoader {
+    pub fn new(target: Target) -> CargoAnalysisLoader {
+        CargoAnalysisLoader {
+            path_prefix: None,
+            target,
+        }
+    }
+}
+
+/// Allows to specify from where and which analysis files will be considered
+/// when reloading data to lower.
 pub trait AnalysisLoader: Sized {
     fn needs_hard_reload(&self, path_prefix: &Path) -> bool;
     fn fresh_host(&self) -> AnalysisHost<Self>;
-    fn set_path_prefix(&self, path_prefix: &Path);
+    fn set_path_prefix(&mut self, path_prefix: &Path);
     fn abs_path_prefix(&self) -> Option<PathBuf>;
-    fn iter_paths<F, T>(&self, f: F) -> Vec<T>
-    where
-        F: Fn(&Path) -> Vec<T>;
+    /// Returns every directory in which analysis files are to be considered.
+    fn search_directories(&self) -> Vec<PathBuf>;
 }
 
 impl AnalysisLoader for CargoAnalysisLoader {
     fn needs_hard_reload(&self, path_prefix: &Path) -> bool {
-        let pp = self.path_prefix.lock().unwrap();
-        pp.is_none() || pp.as_ref().unwrap() != path_prefix
+        self.path_prefix.as_ref().map_or(true, |p| p != path_prefix)
     }
 
     fn fresh_host(&self) -> AnalysisHost<Self> {
-        let pp = self.path_prefix.lock().unwrap();
         AnalysisHost::new_with_loader(CargoAnalysisLoader {
-            path_prefix: Mutex::new(pp.clone()),
-            target: self.target,
+            path_prefix: self.path_prefix.clone(),
+            .. CargoAnalysisLoader::new(self.target)
         })
     }
 
-    fn set_path_prefix(&self, path_prefix: &Path) {
-        let mut pp = self.path_prefix.lock().unwrap();
-        *pp = Some(path_prefix.to_owned())
+    fn set_path_prefix(&mut self, path_prefix: &Path) {
+        self.path_prefix = Some(path_prefix.to_owned());
     }
 
     fn abs_path_prefix(&self) -> Option<PathBuf> {
-        let p = self.path_prefix.lock().unwrap();
-        p.as_ref()
+        self.path_prefix.as_ref()
             .map(|s| Path::new(s).canonicalize().unwrap().to_owned())
     }
 
-    fn iter_paths<F, T>(&self, f: F) -> Vec<T>
-    where
-        F: Fn(&Path) -> Vec<T>,
-    {
-        let path_prefix = self.path_prefix.lock().unwrap();
-        let path_prefix = path_prefix.as_ref().unwrap();
+    fn search_directories(&self) -> Vec<PathBuf> {
+        let path_prefix = self.path_prefix.as_ref().unwrap();
         let target = self.target.to_string();
 
         // TODO sys_root_path allows to break out of 'sandbox' - is that Ok?
@@ -82,12 +88,13 @@ impl AnalysisLoader for CargoAnalysisLoader {
             .join("rustlib")
             .join(&target_triple)
             .join("analysis");
-        let paths = &[&libs_path, &deps_path, &principle_path];
 
-        paths.iter().flat_map(|p| f(p).into_iter()).collect()
+        vec![libs_path, deps_path, principle_path]
     }
 }
 
+// FIXME: This can fail when using a custom toolchain in rustup (often linked to
+// `/$rust_repo/build/$target/stage2`)
 fn extract_target_triple(sys_root_path: &Path) -> String {
     // Extracts nightly-x86_64-pc-windows-msvc from
     // $HOME/.rustup/toolchains/nightly-x86_64-pc-windows-msvc
@@ -121,6 +128,21 @@ fn sys_root_path() -> PathBuf {
             "need to specify SYSROOT or RUSTC env vars, \
              or rustc must be in PATH",
         )
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Target {
+    Release,
+    Debug,
+}
+
+impl fmt::Display for Target {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Target::Release => write!(f, "release"),
+            Target::Debug => write!(f, "debug"),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/lowering.rs
+++ b/src/lowering.rs
@@ -6,11 +6,12 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-// For processing the raw save-analysis data from rustc into rustw's in-memory representation.
+//! For processing the raw save-analysis data from rustc into the rls
+//! in-memory representation.
 
 use analysis::{Def, Glob, PerCrateAnalysis};
 use data;
-use raw::{self, RelationKind};
+use raw::{self, RelationKind, CrateId};
 use {AResult, AnalysisHost, Id, Span, NULL};
 use loader::AnalysisLoader;
 use util;
@@ -31,7 +32,7 @@ pub fn lower<F, L>(
     mut f: F,
 ) -> AResult<()>
 where
-    F: FnMut(&AnalysisHost<L>, PerCrateAnalysis, Option<PathBuf>) -> AResult<()>,
+    F: FnMut(&AnalysisHost<L>, PerCrateAnalysis, CrateId) -> AResult<()>,
     L: AnalysisLoader,
 {
     let rss = util::get_resident().unwrap_or(0);
@@ -40,19 +41,19 @@ where
     for c in raw_analysis {
         let t_start = Instant::now();
 
-        let (per_crate, path) = CrateReader::read_crate(analysis, c, base_dir);
+        let (per_crate, id) = CrateReader::read_crate(analysis, c, base_dir);
 
         let time = t_start.elapsed();
         info!(
-            "Lowering {:?} in {:.2}s",
-            path.as_ref().map(|p| p.display().to_string()),
+            "Lowering {} in {:.2}s",
+            format!("{} ({:?})", id.name, id.disambiguator),
             time.as_secs() as f64 + time.subsec_nanos() as f64 / 1_000_000_000.0
         );
         info!("    defs:  {}", per_crate.defs.len());
         info!("    refs:  {}", per_crate.ref_spans.len());
         info!("    globs: {}", per_crate.globs.len());
 
-        f(analysis, per_crate, path)?;
+        f(analysis, per_crate, id)?;
     }
 
     let time = t_start.elapsed();
@@ -84,6 +85,9 @@ fn lower_span(raw_span: &raw::SpanData, base_dir: &Path) -> Span {
     )
 }
 
+/// Responsible for processing the raw `data::Analysis`, including translating
+/// from local crate ids to global crate ids, and creating lowered
+/// `PerCrateAnalysis`.
 struct CrateReader {
     /// This is effectively a map from local crate id -> global crate id, where
     /// local crate id are indices 0...external_crate_count.
@@ -95,12 +99,13 @@ struct CrateReader {
 impl CrateReader {
     fn from_prelude(
         mut prelude: raw::CratePreludeData,
-        master_crate_map: &mut HashMap<String, u32>,
+        master_crate_map: &mut HashMap<CrateId, u32>,
         base_dir: &Path,
     ) -> CrateReader {
-        fn fetch_crate_id(map: &mut HashMap<String, u32>, crate_name: &String) -> u32 {
+        fn fetch_crate_index(map: &mut HashMap<CrateId, u32>,
+                             id: data::GlobalCrateId) -> u32 {
             let next = map.len() as u32;
-            *map.entry(crate_name.clone()).or_insert(next)
+            *map.entry(id).or_insert(next)
         }
         // When reading a local crate and its external crates, we need to:
         // 1. Update a global crate id map if we encounter any new crate
@@ -108,32 +113,33 @@ impl CrateReader {
         // map those when lowering symbols with local crate ids into global registry
         // It's worth noting, that we assume that local crate id is 0, whereas
         // the external crates will have num in 1..count contiguous range.
-        let crate_name = prelude.crate_id.name.clone();
-        trace!("building crate map for {}", crate_name);
-        let id = fetch_crate_id(master_crate_map, &crate_name);
-        let mut crate_map = vec![id];
-        trace!("  {} -> {}", crate_name, master_crate_map[&crate_name]);
+        let crate_id = prelude.crate_id;
+        trace!("building crate map for {}", crate_id.name);
+        let index = fetch_crate_index(master_crate_map, crate_id.clone());
+        let mut crate_map = vec![index];
+        trace!("  {} -> {}", crate_id.name, master_crate_map[&crate_id]);
 
         prelude.external_crates.sort_by(|a, b| a.num.cmp(&b.num));
         for c in prelude.external_crates {
             assert!(c.num == crate_map.len() as u32);
-            let id = fetch_crate_id(master_crate_map, &c.id.name);
-            crate_map.push(id);
-            trace!("  {} -> {}", c.id.name, master_crate_map[&c.id.name]);
+            let index = fetch_crate_index(master_crate_map, c.id.clone());
+            crate_map.push(index);
+            trace!("  {} -> {}", c.id.name, master_crate_map[&c.id]);
         }
 
         CrateReader {
             crate_map,
             base_dir: base_dir.to_owned(),
-            crate_name: crate_name,
+            crate_name: crate_id.name,
         }
     }
 
+    /// Lowers a given `raw::Crate` into `AnalysisHost`.
     fn read_crate<L: AnalysisLoader>(
         project_analysis: &AnalysisHost<L>,
         krate: raw::Crate,
         base_dir: &Path,
-    ) -> (PerCrateAnalysis, Option<PathBuf>) {
+    ) -> (PerCrateAnalysis, CrateId) {
         let reader = CrateReader::from_prelude(
             krate.analysis.prelude.unwrap(),
             &mut project_analysis.master_crate_map.lock().unwrap(),
@@ -143,15 +149,12 @@ impl CrateReader {
         let mut per_crate = PerCrateAnalysis::new(krate.timestamp);
 
         let is_distro_crate = krate.analysis.config.distro_crate;
-
         reader.read_defs(krate.analysis.defs, &mut per_crate, is_distro_crate);
         reader.read_imports(krate.analysis.imports, &mut per_crate, project_analysis);
         reader.read_refs(krate.analysis.refs, &mut per_crate, project_analysis);
         reader.read_impls(krate.analysis.relations, &mut per_crate, project_analysis);
 
-        per_crate.name = reader.crate_name;
-
-        (per_crate, krate.path)
+        (per_crate, krate.id)
     }
 
     fn read_imports<L: AnalysisLoader>(
@@ -165,7 +168,7 @@ impl CrateReader {
             if !i.value.is_empty() {
                 // A glob import.
                 let glob = Glob { value: i.value };
-                // println!("record glob {:?} {:?}", span, glob);
+                trace!("record glob {:?} {:?}", span, glob);
                 analysis.globs.insert(span, glob);
             } else if let Some(ref ref_id) = i.ref_id {
                 // Import where we know the referred def.
@@ -173,7 +176,7 @@ impl CrateReader {
                 if def_id != NULL && !analysis.def_id_for_span.contains_key(&span) &&
                     (project_analysis.has_def(def_id) || analysis.defs.contains_key(&def_id))
                 {
-                    // println!("record import ref {:?} {:?} {:?} {}", i, span, ref_id, def_id);
+                    trace!("record import ref {:?} {:?} {:?} {}", i, span, ref_id, def_id);
                     analysis.def_id_for_span.insert(span.clone(), def_id);
                     analysis
                         .ref_spans
@@ -341,22 +344,23 @@ impl CrateReader {
     //     }
     // }
 
-    /// Recreates resulting crate-local (u32, u32) id from compiler to a global
-    /// `u64` `Id`, mapping from a local to global crate id.
+    /// Recreates resulting crate-local (`u32`, `u32`) id from compiler
+    /// to a global `u64` `Id`, mapping from a local to global crate id.
     fn id_from_compiler_id(&self, id: &data::Id) -> Id {
         if id.krate == u32::MAX || id.index == u32::MAX {
             return NULL;
         }
 
         let krate = self.crate_map[id.krate as usize] as u64;
-        // Use global crate number for high order bits, then index for least significant bits.
+        // Use global crate number for high order bits,
+        // then index for least significant bits.
         Id((krate << 32) | (id.index as u64))
     }
 }
 
 fn abs_ref_id<L: AnalysisLoader>(
     id: Id,
-    analysis: &mut PerCrateAnalysis,
+    analysis: &PerCrateAnalysis,
     project_analysis: &AnalysisHost<L>,
 ) -> Option<Id> {
     if project_analysis.has_def(id) || analysis.defs.contains_key(&id) {

--- a/src/test/mod.rs
+++ b/src/test/mod.rs
@@ -25,19 +25,13 @@ impl AnalysisLoader for TestAnalysisLoader {
         AnalysisHost::new_with_loader(self.clone())
     }
 
-    fn set_path_prefix(&self, _path_prefix: &Path) {}
+    fn set_path_prefix(&mut self, _path_prefix: &Path) {}
 
     fn abs_path_prefix(&self) -> Option<PathBuf> {
         panic!();
     }
 
-    fn iter_paths<F, T>(&self, f: F) -> Vec<T>
-    where
-        F: Fn(&Path) -> Vec<T>,
-    {
-        let paths = &[&self.path];
-        paths.iter().flat_map(|p| f(p).into_iter()).collect()
-    }
+    fn search_directories(&self) -> Vec<PathBuf> { vec![self.path.clone()] }
 }
 
 #[test]
@@ -64,7 +58,7 @@ fn doc_urls_resolve_correctly() {
                 qualname.is_none() || def.qualname == qualname.unwrap()
             })
             .collect();
-        println!("{:#?}", defs);
+        println!("{}: {:#?}", type_, defs);
         assert_eq!(defs.len(), 1);
         assert_eq!(host.doc_url(&defs[0].span), Ok(url.into()));
     }


### PR DESCRIPTION
Fixes #93. (also includes and is based on #103, can rebase if needed)
Blocked by https://github.com/rust-lang/rust/pull/45468 (emitting crate disambiguators in save-analysis in rustc) and https://github.com/nrc/rls-data/pull/11 (data definitions, this pulls my [crate-source](https://github.com/Xanewok/rls-data/tree/crate-source) branch now).

Pushing this as a single squashed commit, since I did walk in circles a bit and had a lot of back and forth commits. This turned out to be bigger than intended, hope that's okay.

Most important change is that it tries to change the model from mapping `Option<PathBuf> -> PerCrateAnalysis` to `CrateId -> PerCrateAnalysis`.
To support passing multiple in-process analysis data, this effectively disconnects paths from loaded data. `CrateId` contains crate name and disambiguator, meaning it'll be unique for each crate target/version.

I tried to simplify some code and comment  as I go, hope that's also okay.

Some quirks still to solve:
* Changing dependencies for crates changes its crate id; This means that when working on a crate and reloading the new data directly, the old data will be orphaned. One idea is to forcibly reload the ones that are passed directly, e.g. every crate with a given name will be removed from database and new data (with new crate id) will be loaded
* This possibly introduces small performance regressions, since timestamps are checked now after loading the data from files, not before (the blacklist is still respected before) [here](https://github.com/nrc/rls-analysis/compare/master...Xanewok:multi-crates?expand=1#diff-7d3d1c0d5254807a1f6cbc87f39af379R62). This can be easily fixed by adding an additional `PathBuf -> SystemTime` cache (however I didn't want to change the architecture too much now).

To make it more consistent and to make external `AnalysisLoader` implementations more MT-safe, moved Mutex from inside the `CargoAnalysisLoader` to `loader` member itself. This works, but I'm not sure the MT code is safe and consistent in general, so it'd be good to take a look at that later, maybe.

r? @nrc