### PR TITLE
loader: Change RUSTC env var behavior

### DIFF
--- a/src/loader.rs
+++ b/src/loader.rs
@@ -11,6 +11,7 @@
 //! default implementation `CargoAnalysisLoader` for Cargo-emitted save-analysis
 //! files.
 
+use std::env;
 use std::ffi::OsStr;
 use std::fmt;
 use std::path::{Path, PathBuf};
@@ -113,10 +114,11 @@ fn extract_target_triple(sys_root_path: &Path) -> String {
 }
 
 fn sys_root_path() -> PathBuf {
-    option_env!("SYSROOT")
+    env::var("SYSROOT")
+        .ok()
         .map(PathBuf::from)
         .or_else(|| {
-            Command::new(option_env!("RUSTC").unwrap_or("rustc"))
+            Command::new(env::var("RUSTC").unwrap_or(String::from("rustc")))
                 .arg("--print")
                 .arg("sysroot")
                 .output()
@@ -124,10 +126,7 @@ fn sys_root_path() -> PathBuf {
                 .and_then(|out| String::from_utf8(out.stdout).ok())
                 .map(|s| PathBuf::from(s.trim()))
         })
-        .expect(
-            "need to specify SYSROOT or RUSTC env vars, \
-             or rustc must be in PATH",
-        )
+        .expect("need to specify SYSROOT or RUSTC env vars, or rustc must be in PATH")
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
Previously environmental variables were determined at compile time (not desired), and if not present, the call to rustc to get the sysroot would fail. This commit changes the semantics to shell out to rustc in a more predictable fashion.

When merged this will fix #119. After this is released, I can update the RLS's version of rls-analysis, and eventually get these changes out via rust-lang/rust.