### PR TITLE
Add parent to SymbolResult

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,7 @@ pub struct SymbolResult {
     pub name: String,
     pub kind: raw::DefKind,
     pub span: Span,
+    pub parent: Option<Id>,
 }
 
 impl SymbolResult {
@@ -67,6 +68,7 @@ impl SymbolResult {
             name: def.name.clone(),
             span: def.span.clone(),
             kind: def.kind,
+            parent: def.parent,
         }
     }
 }


### PR DESCRIPTION
This will allow the RLS to populate the `container_name` field to provide hierarchical symbol information to clients.

https://github.com/rust-lang-nursery/rls/blob/5d3f9e1fe43c1feaec6a68c5326800c08406ff07/src/actions/requests.rs#L124


https://github.com/rust-lang-nursery/rls-vscode/issues/124