### PR TITLE
Expose SearchDirectory as a public API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ mod test;
 pub use analysis::{Def, Ref};
 use analysis::Analysis;
 pub use raw::{name_space_for_def_kind, read_analysis_from_files, CrateId, DefKind};
-pub use loader::{AnalysisLoader, CargoAnalysisLoader, Target};
+pub use loader::{AnalysisLoader, CargoAnalysisLoader, SearchDirectory, Target};
 pub use symbol_query::SymbolQuery;
 
 use std::collections::HashMap;


### PR DESCRIPTION
AnalysisLoader implementations are expected to produce instances of this
type, but if it's not public that's not possible. So it needs to be
exported.